### PR TITLE
Add API endpoint for source package

### DIFF
--- a/src/webswview/lkswview/api/views.py
+++ b/src/webswview/lkswview/api/views.py
@@ -4,8 +4,17 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from flask import Blueprint
+from flask import Blueprint, abort
 from flask_restful import Api, Resource
+from sqlalchemy.orm import undefer
+
+from laniakea.db import (
+    ArchiveSuite,
+    SourcePackage,
+    session_scope,
+)
+from laniakea.archive import repo_suite_settings_for
+
 
 api = Blueprint('api', __name__, url_prefix='/api')
 api_wrap = Api(api)
@@ -16,4 +25,75 @@ class TodoItem(Resource):
         return {'task': 'Say "Hello, World!"'}
 
 
+class SrcPackage(Resource):
+    def get(self, repo_name, suite_name, name):
+        with session_scope() as session:
+            rss = repo_suite_settings_for(session, repo_name, suite_name, fail_if_missing=False)
+            if not rss:
+                abort(404)
+
+            spkgs = (
+                session.query(SourcePackage)
+                .options(undefer(SourcePackage.version))
+                .filter(SourcePackage.repo_id == rss.repo_id)
+                .filter(SourcePackage.suites.any(ArchiveSuite.id == rss.suite_id))
+                .filter(SourcePackage.name == name)
+                .filter(SourcePackage.time_deleted.is_(None))
+                .order_by(SourcePackage.version.desc())
+                .all()
+            )
+            if not spkgs:
+                abort(404)
+
+            repo = rss.repo
+
+            return {
+                'pkgs': [
+                    {
+                        'uuid': spkg.uuid,
+                        'source_uuid': spkg.source_uuid,
+                        'name': spkg.name,
+                        'version': spkg.version,
+                        # skipping repo because presumably it's same as rss.repo
+                        'suites': [suite.name for suite in spkg.suites],
+                        'time_added': spkg.time_added,
+                        'time_published': spkg.time_published,
+                        'architectures': spkg.architectures,
+                        'maintainer': spkg.maintainer,
+                        'original_maintainer': spkg.original_maintainer,
+                        'uploaders': spkg.uploaders,
+                        'changes_urgency': spkg.changes_urgency,
+                    }
+                    for spkg in spkgs
+                ],
+                'pkg_repo': {
+                    'name': repo.name,
+                    'origin_name': repo.origin_name,
+                },
+            }
+
+
+class Suite(Resource):
+    def get(self, repo_name, suite_name):
+        with session_scope() as session:
+            rss = repo_suite_settings_for(session, repo_name, suite_name, fail_if_missing=False)
+            if not rss:
+                abort(404)
+
+            suite = rss.suite
+
+            return {
+                'name': suite.name,
+                'alias': suite.alias,
+                'summary': suite.summary,
+                'version': suite.version,
+                'architectures': [
+                    { 'name': arch.name }
+                    for arch in suite.architectures
+                ],
+            }
+
+
 api_wrap.add_resource(TodoItem, '/todos/<int:id>')
+api_wrap.add_resource(SrcPackage, '/packages/src/<repo_name>/<suite_name>/<name>')
+api_wrap.add_resource(Suite, '/suites/<repo_name>/<suite_name>')


### PR DESCRIPTION
This is not tested because it's not clear from the docs how to set up the database.

I also based it off of https://software.pureos.net/package/src/landing/squeekboard which doesn't seem to have the "repository" part, so I don't actually know if I would know how to use this endpoint.

Thus, WIP.

The goal is to query the system for the package's progress through various parts of the PureOS infra, and put that there: https://buildstatus.puri.sm/details/deb-squeekboard-byzantium-aarch64
