### PR TITLE
webdash: Go back to the 1st page when switching between job queue modes

### DIFF
--- a/src/webdash/templates/default/jobs/queue.html
+++ b/src/webdash/templates/default/jobs/queue.html
@@ -14,11 +14,11 @@
 
       <div class="buttons has-addons">
         <a class="button {{'is-info is-selected' if not show_blocked}}"
-           href="{{ url_for('jobs.queue', page=current_page, blocked='false')}}">
+           href="{{ url_for('jobs.queue', page=1, blocked='false')}}">
             Only Pending
         </a>
         <a class="button {{'is-info is-selected' if show_blocked}}"
-           href="{{ url_for('jobs.queue', page=current_page, blocked='true')}}">
+           href="{{ url_for('jobs.queue', page=1, blocked='true')}}">
             Pending &amp; Blocked
         </a>
         <a class="button"


### PR DESCRIPTION
A page on one mode may not exist on the other; don't preserve the current page when switching.