### PR TITLE
spears: britneyconfig: Disable Built-Using policy

### DIFF
--- a/src/spears/britneyconfig.py
+++ b/src/spears/britneyconfig.py
@@ -67,6 +67,9 @@ class BritneyConfig:
         # we don't support autopkgtest yet
         self._contents.append('ADT_ENABLE      = no')
 
+        # we don't enforce Built-Using relationships in the archive yet
+        self._contents.append('BUILT_USING_POLICY_ENABLE = no')
+
     def set_archive_paths(self, from_path: str, to_path: str):
         assert not self._paths_set
 


### PR DESCRIPTION
See https://salsa.debian.org/release-team/britney2/-/merge_requests/52

Laniakea does not enforce Built-Using relationship in the archive.