### PR TITLE
Fix a deadlock between autosync and expire jobs

### DIFF
--- a/src/synchrotron/syncengine.py
+++ b/src/synchrotron/syncengine.py
@@ -1121,8 +1121,8 @@ class SyncEngine:
 
         with (
             process_file_lock('sync_{}'.format(self._repo_name)),
-            process_file_lock('publish_{}-{}'.format(self._repo_name, self._target_suite_name), wait=True),
             process_file_lock('archive_expire-{}'.format(self._repo_name), wait=True),
+            process_file_lock('publish_{}-{}'.format(self._repo_name, self._target_suite_name), wait=True),
         ):
             with session_scope() as session:
                 ret = self._autosync_internal(session, remove_cruft)


### PR DESCRIPTION
When the expire job runs, it aquires the `archive_expire-{repo}` lock first and then iterates over suites, acquiring `publish_{repo}-{suite}` locks in the process.

If autosync job starts while expire runs, it will first acquire `publish_{repo}-{suite}` lock and then try to get `archive_expire-{repo}` lock as well, which is already held by the other job, so it will wait for it to get released.

At that point, if the expire job did not process the suite that autosync has taken the lock for yet, it will attempt to acquire it later. This ends up with both jobs holding one lock and waiting for locks held by each other, producing a deadlock.

Make sure that these two locks are always acquired in the same order.